### PR TITLE
Run body closure inside SwiftUI.View.body to activate observation tracking

### DIFF
--- a/Sources/SwiftUIHosting/SwiftUIHostingViewController.swift
+++ b/Sources/SwiftUIHosting/SwiftUIHostingViewController.swift
@@ -40,15 +40,19 @@ open class SwiftUIHostingViewController<Content: View>: UIViewController {
 
     super.viewDidLoad()
 
-    let _content = content(self)
-
     let contentView = SwiftUIHostingView(
       name,
       file,
       function,
       line,
       configuration: configuration
-    ) { _content }
+    ) { [weak self] in
+      if let self {
+        content(self)
+      } else {
+        EmptyView()
+      }
+    }
 
     view.addSubview(contentView)
     contentView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
To let SwiftUI tracks Observable model, properties need to be accessed inside body closure.
But HostingViewController accepts body value not as closure. that means accessing properties of models happened out of body function. Observation framework can't catch that.