### PR TITLE
Update to iOS 17 min API

### DIFF
--- a/Development/Development/ContentView.swift
+++ b/Development/Development/ContentView.swift
@@ -69,7 +69,9 @@ final class KeyboardAvoidanceViewController: UIViewController, UITextFieldDelega
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    let hostingView = SwiftUIHostingView(configuration: .init(ignoresKeyboard: ignoresKeyboard)) { 
+    let hostingView = SwiftUIHostingView(
+      configuration: .init(safeAreaRegions: ignoresKeyboard ? .container : .keyboard)
+    ) {
       Text("Hello")
     }
     

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
   name: "swiftui-hosting",
-  platforms: [.iOS(.v13)],
+  platforms: [.iOS(.v17)],
   products: [
     // Products define the executables and libraries a package produces, and make them visible to other packages.
     .library(

--- a/Sources/SwiftUIHosting/HostingController.swift
+++ b/Sources/SwiftUIHosting/HostingController.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-@available(iOS 13, *)
 final class HostingController<Content: View>: UIHostingController<Content> {
 
   var onViewDidLayoutSubviews: (UIViewController) -> Void = { _ in }
@@ -9,45 +8,14 @@ final class HostingController<Content: View>: UIHostingController<Content> {
 
   init(
     accessibilityIdentifier: String? = nil,
-    disableSafeArea: Bool,
-    ignoresKeyboard: Bool,
+    safeAreaRegions: SafeAreaRegions,
     rootView: Content
   ) {
 
     self.accessibilityIdentifier = accessibilityIdentifier
 
     super.init(rootView: rootView)
-    
-    // waiting for iOS 16.4 as minimum deployment target
-    _disableSafeArea = disableSafeArea
-
-    // https://steipete.com/posts/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/
-    if ignoresKeyboard {
-      guard let viewClass = object_getClass(view) else { return }
-      
-      let viewSubclassName = String(cString: class_getName(viewClass)).appending("_IgnoresKeyboard")
-      if let viewSubclass = NSClassFromString(viewSubclassName) {
-        object_setClass(view, viewSubclass)
-      }
-      else {
-        guard let viewClassNameUtf8 = (viewSubclassName as NSString).utf8String else { return }
-        guard let viewSubclass = objc_allocateClassPair(viewClass, viewClassNameUtf8, 0) else { return }
-        
-        if let method = class_getInstanceMethod(viewClass, NSSelectorFromString("keyboardWillShowWithNotification:")) {
-          let keyboardWillShow: @convention(block) (AnyObject, AnyObject) -> Void = { _, _ in
-            if ignoresKeyboard {
-              
-            } else {
-              
-            }
-          }
-          class_addMethod(viewSubclass, NSSelectorFromString("keyboardWillShowWithNotification:"),
-                          imp_implementationWithBlock(keyboardWillShow), method_getTypeEncoding(method))
-        }
-        objc_registerClassPair(viewSubclass)
-        object_setClass(view, viewSubclass)
-      }
-    }
+    self.safeAreaRegions = safeAreaRegions
   }
 
   @MainActor required dynamic init?(coder aDecoder: NSCoder) {

--- a/Sources/SwiftUIHosting/SwiftUIHostingView.swift
+++ b/Sources/SwiftUIHosting/SwiftUIHostingView.swift
@@ -24,16 +24,14 @@ open class SwiftUIHostingView<Content: View>: UIView {
 
       self.hostingController = HostingController(
         accessibilityIdentifier: _typeName(Content.self),
-        disableSafeArea: configuration.disableSafeArea,
-        ignoresKeyboard: configuration.ignoresKeyboard,
+        safeAreaRegions: configuration.safeAreaRegions,
         rootView: usingContent
       )
 
     #else
 
       self.hostingController = HostingController(
-        disableSafeArea: configuration.disableSafeArea,
-        ignoresKeyboard: configuration.ignoresKeyboard,
+        safeAreaRegions: configuration.safeAreaRegions,
         rootView: usingContent
       )
 
@@ -227,13 +225,7 @@ public struct SwiftUIHostingConfiguration {
    */
   public var registersAsChildViewController: Bool
   
-  /**
-   Fixes handling safe area issue
-   https://www.notion.so/muukii/UIHostingController-safeArea-issue-ec66a560970c4a1cb44f21cc448bc513?pvs=4
-   */
-  public var disableSafeArea: Bool
-  
-  public var ignoresKeyboard: Bool
+  public var safeAreaRegions: SafeAreaRegions
   
   public var sizeMeasureMode: SwiftUIHostingSizeMeasureMode
   
@@ -241,14 +233,12 @@ public struct SwiftUIHostingConfiguration {
   
   public init(
     registersAsChildViewController: Bool = true,
-    disableSafeArea: Bool = true,
-    ignoresKeyboard: Bool = false,
+    safeAreaRegions: SafeAreaRegions = .keyboard,
     sizeMeasureMode: SwiftUIHostingSizeMeasureMode = .systemSizeThatFits,
     baseModifier: BaseModifier = .shared
   ) {
     self.registersAsChildViewController = registersAsChildViewController
-    self.disableSafeArea = disableSafeArea
-    self.ignoresKeyboard = ignoresKeyboard
+    self.safeAreaRegions = safeAreaRegions
     self.sizeMeasureMode = sizeMeasureMode
     self.baseModifier = baseModifier
   }

--- a/Sources/SwiftUIHosting/SwiftUIHostingViewController.swift
+++ b/Sources/SwiftUIHosting/SwiftUIHostingViewController.swift
@@ -46,16 +46,14 @@ open class SwiftUIHostingViewController<Content: View>: UIViewController {
 
       let hostingController = HostingController(
         accessibilityIdentifier: _typeName(Content.self),
-        disableSafeArea: configuration.disableSafeArea,
-        ignoresKeyboard: configuration.ignoresKeyboard,
+        safeAreaRegions: configuration.safeAreaRegions,
         rootView: _content
       )
 
     #else
 
       let hostingController = HostingController(
-        disableSafeArea: configuration.disableSafeArea,
-        ignoresKeyboard: configuration.ignoresKeyboard,
+        safeAreaRegions: configuration.safeAreaRegions,
         rootView: _content
       )
 


### PR DESCRIPTION
We can just use `safeAreaRegions` to replace the previous bools.

This is a breaking change. We could be using a compatibility layer to avoid it, but I think it's not so hard to do the migration, so I did not include it. 

